### PR TITLE
only lower case allowed for configmap name

### DIFF
--- a/component/grafana-extraConfigMap.libsonnet
+++ b/component/grafana-extraConfigMap.libsonnet
@@ -7,7 +7,7 @@ local instance = inv.parameters._instance;
 
 
 {
-  'grafana-extraConfigMap': kube.ConfigMap('grafana-extraConfigMap') {
+  'grafana-extraconfigmap': kube.ConfigMap('grafana-extraconfigmap') {
     metadata+: {
       namespace: params.namespace,
     },


### PR DESCRIPTION
Fix for https://github.com/projectsyn/component-grafana-helm/pull/6